### PR TITLE
Panoramax: fix title, JS in its own folder

### DIFF
--- a/panoramax/config.json
+++ b/panoramax/config.json
@@ -1,5 +1,5 @@
 {
-  "js": ["lib/index.js", "../lib/jquery.easyDrag.min.js", "../lib/panoramax.js"],
+  "js": ["lib/index.js", "../lib/jquery.easyDrag.min.js", "lib/panoramax.js"],
   "html": "panoramax.html",
   "css": "lib/index.css",
   "target": "map",

--- a/panoramax/lib/panoramax.js
+++ b/panoramax/lib/panoramax.js
@@ -50,7 +50,7 @@ var panoramax = (function () {
    */
   var _initToolbarBtn = () => {
     var button = [
-      '<button id="panoramaxBtn" title href="#" type="button" class="btn btn-light" data-original-title="Panoramax" data-toggle="tooltip">' +
+      '<button id="panoramaxBtn" href="#" type="button" class="btn btn-light" title="Panoramax" data-toggle="tooltip">' +
         '<span class="fas fa-street-view"></span>' +
         "</button>",
     ].join("");
@@ -222,7 +222,7 @@ var panoramax = (function () {
         _pnxMapFiltersContainer.innerHTML = `
           <div class="layerdisplay-title">
             <a>Panoramax</a>
-            <a href="#" class="mv-layer-remove" aria-label="close"title="" i18n="theme.layers.remove" data-original-title="Supprimer">
+            <a href="#" class="mv-layer-remove" aria-label="close" title="Supprimer" i18n="theme.layers.remove">
               <i class="ri-close-large-line"></i>
             </a>
           </div>


### PR DESCRIPTION
Based on @lecault feedback: the button title was not showing up, this PR fixes the broken title param. Also, moved `panoramax.js` file back in its addon folder, as it's not a common used library. If a JS file may be put in common lib folder, it's more the `index.js` and `index.css`, but I'm not sure this is used by another addon as well.