### PR TITLE
print - titre de couche editable https://github.com/mviewer/mviewer/issues/1312

### DIFF
--- a/print/README.md
+++ b/print/README.md
@@ -2,6 +2,8 @@
 
 This extension provides a map layout interface to create and print a personalised PDF file.
 
+Legend titles can be edited directly in the print modal. Custom values are kept when the modal is closed and reopened during the same session.
+
 ![image](https://github.com/jdev-org/mviewer/assets/16317988/e84fd308-e08d-4314-812c-1f1403beba92)
 
 Only A4 (portrail/landscape) are available for this version.
@@ -134,6 +136,8 @@ You can find here the corresponding key for each item :
 | legend       | legend       |
 | title        | title        |
 | qrcode       | qrcode       |
+
+For the `legend` item, each layer title is editable directly in the print modal. The edited value is preserved when the modal content is rebuilt or reopened, as long as the page is not reloaded.
 
 ## Grid system
 

--- a/print/js/components/Legend.js
+++ b/print/js/components/Legend.js
@@ -5,6 +5,9 @@
 export const Legend = () => {
   const layerDetails = [...document.querySelectorAll(".mv-layer-details")];
   const TitleAndLegend = layerDetails.map((detail, i) => {
+    const layerId = detail.getAttribute("data-layerid");
+    const legendTitle =
+      detail.getAttribute("data-print-title") || detail.getAttribute("data-title") || "";
     let legend = detail.querySelector(".mv-legend");
     if (legend) {
       // legend from WMS
@@ -21,10 +24,26 @@ export const Legend = () => {
     }
     return `
         <div class="print-legend-img">
-            <p>${detail.getAttribute("data-title")}</p>
+            <p class="print-legend-title" contenteditable="true" data-layerid="${layerId}">${legendTitle}</p>
             ${legend?.outerHTML || legend}
         </div>
         `;
   });
   return TitleAndLegend.join("");
+};
+
+/**
+ * Sync edited legend titles with source layer details so values survive modal rebuilds.
+ * @returns {void}
+ */
+export const initLegendTitleEdition = () => {
+  document.querySelectorAll(".print-legend-title").forEach((title) => {
+    title.addEventListener("input", (event) => {
+      const layerId = event.target.getAttribute("data-layerid");
+      const detail = document.querySelector(`.mv-layer-details[data-layerid="${layerId}"]`);
+      if (detail) {
+        detail.setAttribute("data-print-title", event.target.textContent);
+      }
+    });
+  });
 };

--- a/print/js/components/ModalContent.js
+++ b/print/js/components/ModalContent.js
@@ -1,4 +1,5 @@
 import { createBlock, deleteUselessBlocks, deleteBlocksById } from "./Block.js";
+import { initLegendTitleEdition } from "./Legend.js";
 import Map from "./Map.js";
 
 const parentModalId = "blockViewImpress";
@@ -46,6 +47,7 @@ export default (layoutJson) => {
   // create blocks
 
   createAndAddBlocs(layoutJson.items);
+  initLegendTitleEdition();
   setSize(layoutJson.format, layoutJson.landscape);
   if (mviewer.customComponents.print.printmap) {
     mviewer.customComponents.print.printmap.updateSize();


### PR DESCRIPTION
Cette PR permet de modifier et conserver un titre de couche modifié dans l'interface de disposition des blocs d'impression :

https://github.com/mviewer/mviewer/issues/1312

<img width="1099" height="745" alt="image" src="https://github.com/user-attachments/assets/e7e370f9-eedd-43e5-9b28-97759c6f600c" />


Cette contribution est financé par Hytech Imaging dans le cadre du projet Littosat :

https://www.google.com/search?q=hytech+imagin+littosat&oq=hytech+imagin+littosat&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIGCAEQRRg8MgYIAhBFGDzSAQgyMjg3ajBqNKgCALACAQ&client=ubuntu&sourceid=chrome&ie=UTF-8

Merci à eux.