### PR TITLE
#18 print - personnalisation des blocs d'impression

### DIFF
--- a/print/README.md
+++ b/print/README.md
@@ -51,11 +51,12 @@ In options (create this key if not available), insert `options.mviewer.applicati
 
 You just have to know that the layout template administration is not required and offer default layout (see next chapter).
 
-Only 3 application properties are possible in the config.json file :
+Application properties available in the config.json file :
 
 - `printLayouts` : **required** _string_ - layout template (JSON) URL to use
 - `ownerLogo` : _string_ - default logo to use in informations area
 - `ownerInfos` : _string_ - default text to use in informations area
+- `customStyleDefaults` : _object_ - default values used to initialize style inputs in the print modal
 
   Here a simple example :
 
@@ -65,11 +66,39 @@ Only 3 application properties are possible in the config.json file :
       "print": {
         "printLayouts": "addons/print/layouts/standard.json",
         "ownerLogo": "https://avatars.githubusercontent.com/u/114171481?s=400&u=7fcf63ac01887ece3f5f2d5527e92c10527c7a91&v=4",
-        "ownerInfos": "This is default text to present mviewer map."
+        "ownerInfos": "This is default text to present mviewer map.",
+        "customStyleDefaults": {
+          "backgroundColor": "#ffffff",
+          "borderColor": "#1e90ff",
+          "fontFamily": "Georgia, serif",
+          "fontSize": "14",
+          "fontColor": "#1f2937"
+        }
       }
     }
   }
 ```
+
+Available keys for `customStyleDefaults` :
+
+- `backgroundColor` : _string_ - default background color for blocks
+- `borderColor` : _string_ - default border color for blocks
+- `fontFamily` : _string_ - default font-family value
+- `fontSize` : _string_ - default font size in pixels
+- `fontColor` : _string_ - default text color
+
+## Style panel
+
+The print modal contains a `Style` accordion to edit block styles during the current session.
+
+You can:
+
+- apply a default style to all blocks with `Tous les blocs (défaut)`
+- select a single block from the target list or by clicking a block in the preview
+- apply a specific style only to the selected block
+- revert the selected block to the default style with `Revenir au style par défaut`
+
+Default values displayed in this accordion come from `customStyleDefaults` when present in `config.json`.
 
 **That's all ! Now, learn how to manage and use a custom layout with a simple JSON file.**
 

--- a/print/js/components/Block.js
+++ b/print/js/components/Block.js
@@ -5,8 +5,8 @@ import { Legend } from "./Legend.js";
 
 /**
  * Will create default template HTML string
- * @param {*} settings from items for a given key (e.g legend, mapPrint....)
- * @returns
+ * @param {object} settings Block settings for a given key (e.g. legend, mapPrint).
+ * @returns {string}
  */
 const defaultTemplate = ({
   id,
@@ -112,12 +112,18 @@ export const deleteUselessBlocks = (itemsToDisplay) => {
  */
 export const createBlock = (customInfos) => {
   let infos = defaultBlocksInfos[customInfos.id] || {};
-  return defaultTemplate({ ...infos, ...customInfos, classNames: customInfos.class });
+  const mergedInfos = { ...infos, ...customInfos, classNames: customInfos.class };
+
+  return defaultTemplate({
+    ...mergedInfos,
+  });
 };
 
 /**
  *
- * @returns options according to mviewer id
+ * Return the print addon options associated with the current mviewer application id.
+ *
+ * @returns {object}
  */
 export const getOptions = () => {
   const mviewerId = configuration.getConfiguration().application.id;

--- a/print/js/components/Map.js
+++ b/print/js/components/Map.js
@@ -31,6 +31,12 @@ const defaultControls = {
 };
 
 // HTML string to render
+/**
+ * Build the HTML markup required to host the print map and optional north arrow.
+ *
+ * @param {string} northImgUrl URL of the north arrow image.
+ * @returns {string}
+ */
 const template = (northImgUrl) => {
   const northImg =
     northImgUrl &&
@@ -76,6 +82,12 @@ const getMviewerMapLayers = () => {
   });
 };
 
+/**
+ * Render and initialize the print map component.
+ *
+ * @param {string} [northImgUrl] Optional north arrow image URL.
+ * @returns {void}
+ */
 export default function (northImgUrl) {
   $("#print-mapPrint").append(template(northImgUrl || defaultNorthImgUrl));
 

--- a/print/js/components/ModalContent.js
+++ b/print/js/components/ModalContent.js
@@ -27,6 +27,7 @@ const createAndAddBlocs = (items) => {
  * To force correct format size
  * @param {string} format
  * @param {boolean} landscape
+ * @returns {void}
  */
 const setSize = (format = "A4", landscape) => {
   const viewDiv = document.getElementById(parentModalId);
@@ -41,6 +42,12 @@ const setSize = (format = "A4", landscape) => {
   }
 };
 
+/**
+ * Rebuild the modal preview content from the selected layout.
+ *
+ * @param {object} layoutJson Selected layout configuration.
+ * @returns {void}
+ */
 export default (layoutJson) => {
   printGridContainer.style.display = "grid";
   if (!document.getElementById(parentModalId)) return;

--- a/print/js/components/ToolbarButton.js
+++ b/print/js/components/ToolbarButton.js
@@ -12,6 +12,11 @@ const template = `
   <i class="ri-printer-line"></i>
 </button>`;
 
+/**
+ * Append the print button to the main tools toolbar.
+ *
+ * @returns {void}
+ */
 export default () => {
   $("#toolstoolbar").append(template);
 };

--- a/print/js/components/customStyle/customStyleApplier.js
+++ b/print/js/components/customStyle/customStyleApplier.js
@@ -1,0 +1,281 @@
+import {
+  getCustomStyleInputIds,
+  getCustomStyleOptions,
+  setCustomStyleInputs,
+} from "./customStyleOptions.js";
+import { customStyleBlockLabels } from "../../const.js";
+import {
+  getDefaultStyleState,
+  getSelectedBlockId,
+  getStyleForBlock,
+  resetCustomStyleState,
+  setBlockStyleState,
+  setSelectedBlockId,
+  setDefaultStyleState,
+} from "./customStyleState.js";
+import { getDefaultCustomStyleOptions } from "./customStyleOptions.js";
+
+/**
+ * Return all printable blocks currently rendered in the print grid.
+ *
+ * @returns {HTMLElement[]}
+ */
+const getPrintableBlocks = () => [...document.querySelectorAll("#printGridContainer .blockImpress")];
+
+/**
+ * Convert a block DOM id to its logical block id.
+ *
+ * @param {HTMLElement | null | undefined} blockElement Print block element.
+ * @returns {string | null}
+ */
+const getBlockIdFromElement = (blockElement) => blockElement?.id?.replace(/^print-/, "") || null;
+
+/**
+ * Get the style target selector element.
+ *
+ * @returns {HTMLSelectElement | null}
+ */
+const getTargetSelect = () => document.getElementById("print-style-target");
+
+/**
+ * Get the button used to reset custom styles.
+ *
+ * @returns {HTMLButtonElement | null}
+ */
+const getResetBlockButton = () => document.getElementById("print-style-reset-block");
+
+/**
+ * Return a human-readable label for a block id.
+ *
+ * @param {string} blockId Logical block identifier.
+ * @returns {string}
+ */
+const getBlockLabel = (blockId) => customStyleBlockLabels[blockId] || blockId;
+
+/**
+ * Resolve the main content element inside a print block.
+ *
+ * @param {HTMLElement} block Print block element.
+ * @returns {HTMLElement | null}
+ */
+const getBlockContentElement = (block) =>
+  block.querySelector(".text, .informations, .legend, .qrcode");
+
+/**
+ * Apply a style payload to a single rendered block.
+ *
+ * @param {HTMLElement} block Print block element.
+ * @param {object} [styleOptions={}] Style values to apply.
+ * @returns {void}
+ */
+const applyStylesToBlock = (block, styleOptions = {}) => {
+  block.style.borderColor = styleOptions.borderColor;
+
+  if (block.id !== "print-mapPrint") {
+    const content = getBlockContentElement(block);
+    if (content) {
+      content.style.backgroundColor = styleOptions.backgroundColor;
+      content.style.fontFamily = styleOptions.fontFamily;
+      content.style.fontSize = `${styleOptions.fontSize}px`;
+      content.style.color = styleOptions.fontColor;
+    }
+  }
+
+  const badge = block.querySelector(".badge");
+  if (badge) {
+    badge.style.color = styleOptions.fontColor;
+    badge.style.fontFamily = styleOptions.fontFamily;
+  }
+
+  block.querySelectorAll(".print-legend-img").forEach((legendItem) => {
+    legendItem.style.backgroundColor = styleOptions.backgroundColor;
+    legendItem.style.color = styleOptions.fontColor;
+    legendItem.style.fontFamily = styleOptions.fontFamily;
+    legendItem.style.fontSize = `${styleOptions.fontSize}px`;
+    legendItem.style.border = `1px solid ${styleOptions.borderColor}`;
+  });
+};
+
+/**
+ * Highlight the currently selected block in the print preview.
+ *
+ * @returns {void}
+ */
+const updateSelectedBlockHighlight = () => {
+  const selectedBlockId = getSelectedBlockId();
+
+  getPrintableBlocks().forEach((block) => {
+    const isSelected = getBlockIdFromElement(block) === selectedBlockId;
+    block.classList.toggle("print-style-selected", isSelected);
+  });
+};
+
+/**
+ * Reflect the current block selection into the style form fields.
+ *
+ * @returns {void}
+ */
+const syncStyleInputsWithSelection = () => {
+  const selectedBlockId = getSelectedBlockId();
+  const selectedStyle =
+    selectedBlockId === "default" ? getDefaultStyleState() : getStyleForBlock(selectedBlockId);
+
+  setCustomStyleInputs(selectedStyle);
+
+  const resetButton = getResetBlockButton();
+  if (resetButton) {
+    resetButton.disabled = false;
+  }
+};
+
+/**
+ * Keep the target selector synchronized with the style state.
+ *
+ * @returns {void}
+ */
+const syncTargetSelectValue = () => {
+  const targetSelect = getTargetSelect();
+  if (targetSelect) {
+    targetSelect.value = getSelectedBlockId();
+  }
+};
+
+/**
+ * Reapply the stored custom styles to all visible print blocks.
+ *
+ * @returns {void}
+ */
+export const applyCurrentCustomStyles = () => {
+  getPrintableBlocks().forEach((block) => {
+    applyStylesToBlock(block, getStyleForBlock(getBlockIdFromElement(block)));
+  });
+
+  updateSelectedBlockHighlight();
+};
+
+/**
+ * Persist the currently edited style values for the selected target.
+ *
+ * @returns {void}
+ */
+const handleStyleInputChange = () => {
+  const selectedBlockId = getSelectedBlockId();
+  const currentStyle = getCustomStyleOptions();
+
+  if (selectedBlockId === "default") {
+    setDefaultStyleState(currentStyle);
+  } else {
+    setBlockStyleState(selectedBlockId, currentStyle);
+  }
+
+  applyCurrentCustomStyles();
+  syncStyleInputsWithSelection();
+};
+
+/**
+ * Change the active style target and refresh the related UI state.
+ *
+ * @param {string} blockId Selected target id.
+ * @returns {void}
+ */
+const handleTargetChange = (blockId) => {
+  setSelectedBlockId(blockId);
+  syncTargetSelectValue();
+  syncStyleInputsWithSelection();
+  updateSelectedBlockHighlight();
+};
+
+/**
+ * Bind form inputs used to edit custom style values.
+ *
+ * @returns {void}
+ */
+const bindStyleInputEvents = () => {
+  getCustomStyleInputIds().forEach((inputId) => {
+    const input = document.getElementById(inputId);
+    if (!input) return;
+    input.oninput = handleStyleInputChange;
+    input.onchange = handleStyleInputChange;
+  });
+};
+
+/**
+ * Bind selector and reset actions for the custom style panel.
+ *
+ * @returns {void}
+ */
+const bindTargetEvents = () => {
+  const targetSelect = getTargetSelect();
+  if (targetSelect) {
+    targetSelect.onchange = (event) => handleTargetChange(event.target.value);
+  }
+
+  const resetButton = getResetBlockButton();
+  if (resetButton) {
+    resetButton.onclick = (event) => {
+      event.preventDefault();
+      resetCustomStyleState();
+      setCustomStyleInputs(getDefaultCustomStyleOptions());
+      syncTargetOptions();
+      syncStyleInputsWithSelection();
+      applyCurrentCustomStyles();
+    };
+  }
+};
+
+/**
+ * Allow direct block selection from the print preview.
+ *
+ * @returns {void}
+ */
+const bindBlockSelectionEvents = () => {
+  getPrintableBlocks().forEach((block) => {
+    block.onclick = (event) => {
+      if (event.target.closest(".print-panel-close")) return;
+      handleTargetChange(getBlockIdFromElement(block));
+    };
+  });
+};
+
+/**
+ * Rebuild the style target options from currently rendered blocks.
+ *
+ * @returns {void}
+ */
+const syncTargetOptions = () => {
+  const targetSelect = getTargetSelect();
+  if (!targetSelect) return;
+
+  const blockOptions = getPrintableBlocks()
+    .map((block) => getBlockIdFromElement(block))
+    .filter(Boolean)
+    .map((blockId) => `<option value="${blockId}">${getBlockLabel(blockId)}</option>`);
+
+  targetSelect.innerHTML = [
+    `<option value="default">Tous les blocs (défaut)</option>`,
+    ...blockOptions,
+  ].join("");
+
+  if (
+    getSelectedBlockId() !== "default" &&
+    !blockOptions.some((option) => option.includes(`value="${getSelectedBlockId()}"`))
+  ) {
+    setSelectedBlockId("default");
+  }
+
+  syncTargetSelectValue();
+};
+
+/**
+ * Reinitialize style controls after the modal content is rebuilt.
+ *
+ * @returns {void}
+ */
+export const refreshCustomStyleContext = () => {
+  syncTargetOptions();
+  bindTargetEvents();
+  bindStyleInputEvents();
+  bindBlockSelectionEvents();
+  syncStyleInputsWithSelection();
+  updateSelectedBlockHighlight();
+};

--- a/print/js/components/customStyle/customStyleOptions.js
+++ b/print/js/components/customStyle/customStyleOptions.js
@@ -1,0 +1,61 @@
+import { getOptions } from "../Block.js";
+import { customStyleInputs, defaultCustomStyleOptions } from "../../const.js";
+
+/**
+ * Return the DOM ids of every custom style input.
+ *
+ * @returns {string[]}
+ */
+export const getCustomStyleInputIds = () => Object.values(customStyleInputs);
+
+/**
+ * Read style defaults provided by the print addon configuration.
+ *
+ * @returns {object}
+ */
+const getConfiguredCustomStyleOptions = () => {
+  const pluginOptions = getOptions?.() || {};
+  return pluginOptions.customStyleDefaults || {};
+};
+
+/**
+ * Merge hardcoded defaults with configured print style defaults.
+ *
+ * @returns {object}
+ */
+export const getDefaultCustomStyleOptions = () => ({
+  ...defaultCustomStyleOptions,
+  ...getConfiguredCustomStyleOptions(),
+});
+
+/**
+ * Read the current custom style form values.
+ *
+ * @returns {object}
+ */
+export const getCustomStyleOptions = () => {
+  const defaultOptions = getDefaultCustomStyleOptions();
+
+  return Object.entries(customStyleInputs).reduce((options, [key, inputId]) => {
+    const input = document.getElementById(inputId);
+    options[key] = input?.value || defaultOptions[key];
+    return options;
+  }, {});
+};
+
+/**
+ * Populate the custom style form with the provided values.
+ *
+ * @param {object} [styleOptions={}] Partial or full style options.
+ * @returns {void}
+ */
+export const setCustomStyleInputs = (styleOptions = {}) => {
+  const mergedOptions = { ...getDefaultCustomStyleOptions(), ...styleOptions };
+
+  Object.entries(customStyleInputs).forEach(([key, inputId]) => {
+    const input = document.getElementById(inputId);
+    if (input) {
+      input.value = mergedOptions[key];
+    }
+  });
+};

--- a/print/js/components/customStyle/customStyleState.js
+++ b/print/js/components/customStyle/customStyleState.js
@@ -1,0 +1,99 @@
+import { getDefaultCustomStyleOptions } from "./customStyleOptions.js";
+
+const styleState = {
+  defaultStyle: getDefaultCustomStyleOptions(),
+  blockStyles: {},
+  selectedBlockId: "default",
+};
+
+/**
+ * Reset all stored style overrides to their initial values.
+ *
+ * @returns {void}
+ */
+export const resetCustomStyleState = () => {
+  styleState.defaultStyle = getDefaultCustomStyleOptions();
+  styleState.blockStyles = {};
+  styleState.selectedBlockId = "default";
+};
+
+/**
+ * Return the current default style state.
+ *
+ * @returns {object}
+ */
+export const getDefaultStyleState = () => ({ ...styleState.defaultStyle });
+
+/**
+ * Replace the default style applied to all blocks without dedicated overrides.
+ *
+ * @param {object} styleOptions Style values to persist as defaults.
+ * @returns {void}
+ */
+export const setDefaultStyleState = (styleOptions) => {
+  styleState.defaultStyle = { ...styleOptions };
+};
+
+/**
+ * Return the saved style override for a specific block.
+ *
+ * @param {string} blockId Logical block identifier.
+ * @returns {object | null}
+ */
+export const getBlockStyleState = (blockId) => {
+  if (!blockId || !styleState.blockStyles[blockId]) {
+    return null;
+  }
+
+  return { ...styleState.blockStyles[blockId] };
+};
+
+/**
+ * Persist a style override for a specific block.
+ *
+ * @param {string} blockId Logical block identifier.
+ * @param {object} styleOptions Style values for the block.
+ * @returns {void}
+ */
+export const setBlockStyleState = (blockId, styleOptions) => {
+  if (!blockId || blockId === "default") return;
+  styleState.blockStyles[blockId] = { ...styleOptions };
+};
+
+/**
+ * Remove a saved block-specific style override.
+ *
+ * @param {string} blockId Logical block identifier.
+ * @returns {void}
+ */
+export const clearBlockStyleState = (blockId) => {
+  if (!blockId || blockId === "default") return;
+  delete styleState.blockStyles[blockId];
+};
+
+/**
+ * Return the currently selected style target id.
+ *
+ * @returns {string}
+ */
+export const getSelectedBlockId = () => styleState.selectedBlockId;
+
+/**
+ * Update the currently selected style target.
+ *
+ * @param {string} blockId Logical block identifier.
+ * @returns {void}
+ */
+export const setSelectedBlockId = (blockId) => {
+  styleState.selectedBlockId = blockId || "default";
+};
+
+/**
+ * Resolve the effective style for a block, falling back to the default style.
+ *
+ * @param {string} blockId Logical block identifier.
+ * @returns {object}
+ */
+export const getStyleForBlock = (blockId) => {
+  return getBlockStyleState(blockId) || getDefaultStyleState();
+};

--- a/print/js/components/customStyle/index.js
+++ b/print/js/components/customStyle/index.js
@@ -1,0 +1,71 @@
+/**
+ * Render the custom style accordion displayed in the print options panel.
+ *
+ * @returns {string}
+ */
+export default () => `
+  <div class="accordion my-4" id="print-style-accordion">
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="print-style-heading">
+        <button
+          class="accordion-button collapsed"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#print-style-collapse"
+          aria-expanded="false"
+          aria-controls="print-style-collapse"
+        >
+          Style
+        </button>
+      </h2>
+      <div
+        id="print-style-collapse"
+        class="accordion-collapse collapse"
+        aria-labelledby="print-style-heading"
+        data-bs-parent="#print-style-accordion"
+      >
+        <div class="accordion-body">
+          <div class="mb-3 print-style-field-row">
+            <label for="print-style-target" class="form-label mb-0">Cible</label>
+            <select id="print-style-target" class="form-select">
+              <option value="default">Tous les blocs (défaut)</option>
+            </select>
+          </div>
+          <div class="mb-3 print-style-field-row print-style-color-row">
+            <label for="print-background-color" class="form-label mb-0">Couleur du fond</label>
+            <input id="print-background-color" type="color" class="form-control form-control-color" value="#ffffff">
+          </div>
+          <div class="mb-3 print-style-field-row print-style-color-row">
+            <label for="print-border-color" class="form-label mb-0">Couleur du trait du bloc</label>
+            <input id="print-border-color" type="color" class="form-control form-control-color" value="#808080">
+          </div>
+          <div class="mb-3 print-style-field-row print-style-size-row">
+            <label for="print-font-size" class="form-label mb-0">Taille de police</label>
+            <input id="print-font-size" type="number" min="8" max="48" step="1" class="form-control" value="16">
+          </div>
+          <div class="mb-3 print-style-field-row print-style-color-row">
+            <label for="print-font-color" class="form-label mb-0">Couleur de police</label>
+            <input id="print-font-color" type="color" class="form-control form-control-color" value="#1f2937">
+          </div>
+          <div class="mb-0 print-style-field-row">
+            <label for="print-font-family" class="form-label mb-0">Type de police</label>
+            <select id="print-font-family" class="form-select">
+              <option value="inherit">Par défaut</option>
+              <option value="Arial, sans-serif">Arial</option>
+              <option value="'Helvetica Neue', Helvetica, sans-serif">Helvetica Neue</option>
+              <option value="'Times New Roman', serif">Times New Roman</option>
+              <option value="Georgia, serif">Georgia</option>
+              <option value="'Courier New', monospace">Courier New</option>
+              <option value="Verdana, sans-serif">Verdana</option>
+            </select>
+          </div>
+          <div class="mt-3 d-flex justify-content-end default-style-bloc">
+            <button type="button" id="print-style-reset-block" class="btn btn-outline-secondary btn-sm">
+              Revenir au style par défaut
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+`;

--- a/print/js/const.js
+++ b/print/js/const.js
@@ -1,4 +1,10 @@
 const dateString = new Date().toLocaleDateString();
+
+/**
+ * Default metadata used to create print blocks when a layout does not override them.
+ *
+ * @type {Object<string, object>}
+ */
 export const defaultBlocksInfos = {
   title: {
     title: "Titre",
@@ -40,4 +46,44 @@ export const defaultBlocksInfos = {
     zindex: 2,
   },
   mapPrint: { row: "2 / 6", col: "1 / 2", placeHolder: "", title: "Carte", zindex: 1 },
+};
+
+/**
+ * Default custom style values applied in the print style panel.
+ *
+ * @type {Object<string, string>}
+ */
+export const defaultCustomStyleOptions = {
+  backgroundColor: "#ffffff",
+  borderColor: "#808080",
+  fontFamily: "inherit",
+  fontSize: "16",
+  fontColor: "#1f2937",
+};
+
+/**
+ * DOM ids of form inputs used to edit print custom styles.
+ *
+ * @type {Object<string, string>}
+ */
+export const customStyleInputs = {
+  backgroundColor: "print-background-color",
+  borderColor: "print-border-color",
+  fontFamily: "print-font-family",
+  fontSize: "print-font-size",
+  fontColor: "print-font-color",
+};
+
+/**
+ * Labels displayed for selectable print blocks in the custom style panel.
+ *
+ * @type {Object<string, string>}
+ */
+export const customStyleBlockLabels = {
+  mapPrint: "Carte",
+  title: "Titre",
+  legend: "Légende",
+  informations: "Informations",
+  comments: "Commentaires",
+  qrcode: "QR Code",
 };

--- a/print/js/print.js
+++ b/print/js/print.js
@@ -1,6 +1,17 @@
 import ToolbarButton from "./components/ToolbarButton.js";
 
-import { initOptions } from "./utils/printOptions.js";
+import {
+  applyCurrentBlockStyles,
+  initOptions,
+} from "./utils/printOptions.js";
+import {
+  getDefaultCustomStyleOptions,
+  setCustomStyleInputs,
+} from "./components/customStyle/customStyleOptions.js";
+import {
+  refreshCustomStyleContext,
+} from "./components/customStyle/customStyleApplier.js";
+import { resetCustomStyleState } from "./components/customStyle/customStyleState.js";
 
 import { filterCheckBox, iniCheckBox } from "./utils/controls.js";
 
@@ -11,6 +22,11 @@ import ModalContent from "./components/ModalContent.js";
 
 import { getOptions } from "./components/Block.js";
 
+/**
+ * Bind modal close cleanup to remove recreated print blocks and map container.
+ *
+ * @returns {void}
+ */
 const onCloseModal = () => {
   const btnClose = document.getElementById("closePrintModal");
   btnClose.onclick = () => {
@@ -20,6 +36,12 @@ const onCloseModal = () => {
   };
 };
 
+/**
+ * Initialize modal listeners and print actions for a resolved layout configuration.
+ *
+ * @param {Object<string, object>} layout Layout definitions loaded from config.
+ * @returns {void}
+ */
 const initWithLayout = (layout) => {
   $("#printModal").on("shown.bs.modal", function () {
     // supprime et recréer la carte seulement et non toute la modal
@@ -29,6 +51,8 @@ const initWithLayout = (layout) => {
     // init modal
     const layoutToUse = getSelectedLayout(layout);
     ModalContent(layoutToUse);
+    refreshCustomStyleContext();
+    applyCurrentBlockStyles();
     // manage checkbox display
     filterCheckBox(layoutToUse);
     // init checbox check event
@@ -36,7 +60,11 @@ const initWithLayout = (layout) => {
     document.querySelector(".print-reset-btn").addEventListener("click", () => {
       // init modal
       const layoutSelected = getSelectedLayout(layout);
+      resetCustomStyleState();
+      setCustomStyleInputs(getDefaultCustomStyleOptions());
       ModalContent(layoutSelected);
+      refreshCustomStyleContext();
+      applyCurrentBlockStyles();
     });
   });
   // preview PDF button listener
@@ -84,6 +112,11 @@ const initWithLayout = (layout) => {
   onCloseModal();
 };
 
+/**
+ * Bootstrap the print addon and load configured layouts.
+ *
+ * @returns {void}
+ */
 const init = () => {
   // call json template file to render layout
   downloadLayouts(getOptions().printLayouts)

--- a/print/js/utils/defaultLayout.js
+++ b/print/js/utils/defaultLayout.js
@@ -1,3 +1,8 @@
+/**
+ * Built-in fallback print layout used when the external layout file cannot be loaded.
+ *
+ * @type {Object<string, object>}
+ */
 export const defaultLayout = {
   A4_LANDSCAPE: {
     format: "A4 (default)",

--- a/print/js/utils/layout.js
+++ b/print/js/utils/layout.js
@@ -1,7 +1,7 @@
 /**
  * Will request layout JSON file from URL
  * @param {string} url
- * @returns
+ * @returns {Promise<object>}
  */
 export const downloadLayouts = (url) => {
   return fetch(url)
@@ -22,7 +22,7 @@ export const downloadLayouts = (url) => {
  *
  * @param {object} jsonLayout
  * @param {string} format always A4 for this first version
- * @returns
+ * @returns {object | undefined}
  */
 export const getSelectedLayout = (jsonLayout, format = "A4") => {
   let formats = _.keys(jsonLayout).map((k) => jsonLayout[k]);

--- a/print/js/utils/pdf.js
+++ b/print/js/utils/pdf.js
@@ -23,7 +23,7 @@ const defaultOptions = {
  * Prepare divs and block to create a clean print document.
  * Required steps to hide badge, force size, update map etc...
  * @param {object} options
- * @returns
+ * @returns {HTMLElement}
  */
 const preparePrintElement = (options) => {
   var element = document.getElementById("printGridContainer");
@@ -42,6 +42,7 @@ const preparePrintElement = (options) => {
 /**
  * Download print as PDF
  * @param {object} options to override default options
+ * @returns {void}
  */
 export const downloadPDF = (options) => {
   const finalOptions = { ...defaultOptions, ...options };
@@ -59,6 +60,7 @@ export const downloadPDF = (options) => {
 /**
  * Display print as PDF in new tab
  * @param {object} options to override default options
+ * @returns {void}
  */
 export const displayPDF = (options) => {
   const finalOptions = { ...defaultOptions, ...options };
@@ -79,6 +81,7 @@ export const displayPDF = (options) => {
 /**
  * Download print as PNG
  * @param {object} options to override default options
+ * @returns {void}
  */
 export const displayAsPng = (options) => {
   const finalOptions = { ...defaultOptions, ...options };

--- a/print/js/utils/printOptions.js
+++ b/print/js/utils/printOptions.js
@@ -1,26 +1,47 @@
 import ModalContent from "../components/ModalContent.js";
+import customStyle from "../components/customStyle/index.js";
 import { filterCheckBox } from "./controls.js";
+import {
+  applyCurrentCustomStyles,
+  refreshCustomStyleContext,
+} from "../components/customStyle/customStyleApplier.js";
 import { getSelectedLayout } from "./layout.js";
 
 /**
  * Will create event on combobox orientation change.
  * On change, will create modal content according to selected layout and config.
  * @param {object} layoutJson from config
- * @returns
+ * @returns {void}
  */
 const activeOrientationChangeAction = (layoutJson) => {
   const selectOrientation = document.getElementById("print-select-orientation");
   if (!selectOrientation) return;
-  selectOrientation.addEventListener("change", () => {
+  selectOrientation.onchange = () => {
     const layoutToUse = getSelectedLayout(layoutJson);
     ModalContent(layoutToUse);
     filterCheckBox(layoutToUse);
-  });
+    refreshCustomStyleContext();
+    applyCurrentCustomStyles();
+  };
+};
+
+export const applyCurrentBlockStyles = applyCurrentCustomStyles;
+
+/**
+ * Inject the custom style accordion into its dedicated placeholder.
+ *
+ * @returns {void}
+ */
+const renderCustomStylePanel = () => {
+  const container = document.getElementById("print-custom-style-slot");
+  if (!container) return;
+  container.innerHTML = customStyle();
 };
 
 /**
  * Read available orientations from config file.
  * @param {layout} json config from file
+ * @returns {void}
  */
 export const readOrientationOptions = (json) => {
   let formats = Object.keys(json);
@@ -42,10 +63,13 @@ export const readOrientationOptions = (json) => {
 /**
  * Will create or populate options panels and use current theme style.
  * @param {object} jsonLayout from config file
+ * @returns {void}
  */
 export const initOptions = (jsonLayout) => {
   readOrientationOptions(jsonLayout);
+  renderCustomStylePanel();
   activeOrientationChangeAction(jsonLayout);
+  refreshCustomStyleContext();
 
   document.querySelectorAll("#blockOptionsImpress .panel-heading").forEach((x) => {
     x.style.backgroundColor = $("#mv-navbar").css("background-color");

--- a/print/print.html
+++ b/print/print.html
@@ -60,9 +60,7 @@
                 <label class="form-check-label">QR Code (partage de la carte)</label>
               </div>
           </div>
-
-          <!-- Single button -->
-          <div class="print-actions mt-5">
+          <div class="print-actions my-4">
             <button
               type="button"
               class="btn btn-outline-primary print-reset-btn"
@@ -103,6 +101,7 @@
               </ul>
             </div>
           </div>
+          <div id="print-custom-style-slot"></div>
         </div>
         <div
           id="blockViewImpress"

--- a/print/style.css
+++ b/print/style.css
@@ -42,6 +42,74 @@
 
 #blockOptionsImpress {
     margin-right: 2em;
+    min-width: 280px;
+    max-width: 360px;
+}
+
+.print-actions {
+	display: flex;
+	flex-wrap: nowrap;
+	gap: 10px;
+	align-items: stretch;
+}
+
+.print-actions > .btn,
+.print-actions > .btn-group {
+	flex: 1 1 140px;
+}
+
+.print-actions .btn-group {
+	display: flex;
+}
+
+.print-actions .btn-group > .btn {
+	flex: 1 1 auto;
+}
+
+.print-actions .btn,
+.print-actions .dropdown-menu {
+	font-size: 0.875rem;
+}
+
+.print-actions .btn {
+	padding: 0.375rem 0.65rem;
+}
+
+.print-style-field-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.print-style-field-row .form-select,
+.print-style-field-row .form-control:not(.form-control-color) {
+	flex: 0 1 11rem;
+	min-width: 0;
+}
+
+.print-style-color-row .form-control-color {
+	flex: 0 0 auto;
+	width: 3rem;
+	min-width: 3rem;
+	padding: 0.2rem;
+}
+
+.print-style-field-row .form-label {
+	margin-bottom: 0;
+}
+
+.print-style-size-row .form-control {
+	flex-basis: 5rem;
+	max-width: 5rem;
+}
+
+.default-style-bloc {
+	width: 100%;
+}
+
+.default-style-bloc .btn {
+	width: 100%;
 }
 
 .print .print-panel-close {
@@ -57,6 +125,12 @@
 	min-height: fit-content;
 	max-width: 100%;
     max-height: 100%;
+	cursor: pointer;
+}
+
+.blockImpress.print-style-selected {
+	outline: 3px solid #0d6efd;
+	outline-offset: 2px;
 }
 
 .blockImpress .badge {
@@ -216,4 +290,31 @@
 .print-logo {
 	max-height:60px;
 	max-width: 65%;
+}
+@media (max-width: 1200px) {
+	.bodyFlex {
+		flex-wrap: wrap;
+	}
+
+	#blockOptionsImpress {
+		margin-right: 0;
+		margin-bottom: 1.5rem;
+		max-width: 100%;
+		width: 100%;
+	}
+
+	#blockViewImpress {
+		width: 100%;
+	}
+}
+
+@media (max-width: 576px) {
+	#printModal .modal-dialog {
+		max-width: 96% !important;
+	}
+
+	.print-actions > .btn,
+	.print-actions > .btn-group {
+		flex-basis: 100%;
+	}
 }


### PR DESCRIPTION
Cette PR a été financé par Hytech Imagine dans le cadre du projet Littosat.
https://hytech-imaging.fr/littosat/

Cette contribution permet de rajouter au module d'impression, des fonctionnalités de personnalisation du style des blocs (couleurs, police).

<img width="1543" height="791" alt="image" src="https://github.com/user-attachments/assets/37f8e4d5-3073-48f9-ac36-948fb387f9e5" />


L'utilisateur peut cliquer sur un block pour le sélectionner ou utiliser la liste prévue.