### PR TITLE
print - Complete readme, keep default style css by block item

### DIFF
--- a/print/README.md
+++ b/print/README.md
@@ -314,6 +314,8 @@ Example from `layouts/littosat.json` :
 }
 ```
 
+> Note : `content` parameter is only available with custom block element.
+
 Implementation details :
 
 - `js/components/ModalContent.js` loops through `layoutJson.items` and creates one block for each declared item.

--- a/print/js/components/customStyle/customStyleApplier.js
+++ b/print/js/components/customStyle/customStyleApplier.js
@@ -68,16 +68,19 @@ const getBlockContentElement = (block) =>
  * @param {object} [styleOptions={}] Style values to apply.
  * @returns {void}
  */
-const applyStylesToBlock = (block, styleOptions = {}) => {
+const applyStylesToBlock = (block, styleOptions = {}, styleFromCfg) => {
   block.style.borderColor = styleOptions.borderColor;
 
   if (block.id !== "print-mapPrint") {
     const content = getBlockContentElement(block);
     if (content) {
-      content.style.backgroundColor = styleOptions.backgroundColor;
-      content.style.fontFamily = styleOptions.fontFamily;
-      content.style.fontSize = `${styleOptions.fontSize}px`;
-      content.style.color = styleOptions.fontColor;
+        content.style.backgroundColor = styleOptions.backgroundColor;
+        content.style.fontFamily = styleOptions.fontFamily;
+        content.style.fontSize = `${styleOptions.fontSize}px`;
+        content.style.color = styleOptions.fontColor;
+        if(styleFromCfg) {
+          content.style.cssText += ";" + (styleFromCfg || "");
+        }
     }
   }
 
@@ -145,9 +148,11 @@ const syncTargetSelectValue = () => {
  *
  * @returns {void}
  */
-export const applyCurrentCustomStyles = () => {
+export const applyCurrentCustomStyles = (layout) => {
   getPrintableBlocks().forEach((block) => {
-    applyStylesToBlock(block, getStyleForBlock(getBlockIdFromElement(block)));
+    const id = block.id.replace(/^print-/, "");
+    const stylePropFromConfig = (layout?.items?.[id] || {})?.style;
+    applyStylesToBlock(block, getStyleForBlock(getBlockIdFromElement(block)), stylePropFromConfig);
   });
 
   updateSelectedBlockHighlight();
@@ -159,7 +164,7 @@ export const applyCurrentCustomStyles = () => {
  * @returns {void}
  */
 const handleStyleInputChange = () => {
-  const selectedBlockId = getSelectedBlockId();
+    const selectedBlockId = getSelectedBlockId();
   const currentStyle = getCustomStyleOptions();
 
   if (selectedBlockId === "default") {

--- a/print/js/print.js
+++ b/print/js/print.js
@@ -52,7 +52,7 @@ const initWithLayout = (layout) => {
     const layoutToUse = getSelectedLayout(layout);
     ModalContent(layoutToUse);
     refreshCustomStyleContext();
-    applyCurrentBlockStyles();
+    applyCurrentBlockStyles(layoutToUse);
     // manage checkbox display
     filterCheckBox(layoutToUse);
     // init checbox check event


### PR DESCRIPTION
Cette PR : 

- complète le README
- Corrige la conservation du paramètre style des blocs (effacé par les valeurs par défaut du gestionnaire UI de style lors de son initialisation). Attention, si l'utilisateur modifie une règle des champs de gestion des styles, alors toutes les règles par défaut et celles modifiées sont appliquées sur le bloc. La valeur de style par défaut est donc effacée.